### PR TITLE
[WIP] fix export indexDB on android

### DIFF
--- a/src/db/base.ts
+++ b/src/db/base.ts
@@ -35,6 +35,8 @@ abstract class DbProvider {
     abstract importDB(data: any): Promise<void>;
     // 导出数据库
     abstract exportDB(): Promise<void>;
+    // json字符串数据库
+    abstract readDB(): Promise<string>;
 }
 
 

--- a/src/db/local_db.ts
+++ b/src/db/local_db.ts
@@ -289,7 +289,14 @@ export class LocalDb extends DbProvider {
             console.error("error exporting database");
         }
     }
-
+    async readDB() {
+        let blob = await exportDB(this.idb);
+        try {
+            return await blob.text();
+        } catch (e){
+            console.error("error reading database")
+        }
+    }
     async destroyAll() {
         return this.idb.delete();
     }

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -9,6 +9,7 @@ export default {
     "Search word": "Search word",
     "Refresh Word Database": "Refresh Word Database",
     "Refresh Review Database": "Refresh Review Database",
+    "Backup Local Database": "Backup Local Database",
 
     // DataPanelView.ts
     "Data Panel": "Data Panel",
@@ -132,6 +133,7 @@ export default {
     "Warning: Import will override current database": "Warning: Import will override current database",
     "Import": "Import",
     "Export": "Export",
+    "Backup": "Backup",
     "Get all ignores": "Get all ignores",
     "Get all non-ignores": "Get all non-ignores",
     "Copied to clipboard": "Copied to clipboard",

--- a/src/lang/locale/zh.ts
+++ b/src/lang/locale/zh.ts
@@ -9,6 +9,7 @@ export default {
     "Search word": "查找单词/短语",
     "Refresh Word Database": "刷新单词数据库",
     "Refresh Review Database": "刷新复习数据库",
+    "Backup Local Database": "备份学习数据库",
 
     // DataPanelView.ts
     "Data Panel": "单词列表",
@@ -131,6 +132,7 @@ export default {
     "Warning: Import will override current database": "警告: 导入会覆盖掉当前的数据库",
     "Import": "导入",
     "Export": "导出",
+    "Backup": "备份",
     "Get all ignores": "获取所有无视单词",
     "Get all non-ignores": "获取所有非无视单词",
     "Copied to the clipboard": "已复制到剪贴板",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -180,6 +180,13 @@ export default class LanguageLearner extends Plugin {
             callback: this.refreshReviewDb,
         });
 
+        // 注册备份数据库命令
+        this.addCommand({
+            id: "langr-backup-database",
+            name: t("Backup Local Database"),
+            callback: this.backupDb,
+        });
+
         // 注册查词命令
         this.addCommand({
             id: "langr-search-word-select",
@@ -382,6 +389,25 @@ export default class LanguageLearner extends Plugin {
 
         newText = "#flashcards\n\n" + newText;
         await this.app.vault.modify(db, newText);
+
+        this.saveSettings();
+    };
+
+    backupDb = async () => {
+
+        let backupFile = this.app.vault.getAbstractFileByPath(
+            // TODO: add setting for backup filename
+            "wordDB_backup.json"
+        );
+
+        if (!backupFile || "children" in backupFile) {
+            new Notice("Invalid word database path");
+            return;
+        }
+        const db_json = await this.db.readDB();
+        let db = backupFile as TFile;
+        await this.app.vault.modify(db, db_json)
+        new Notice("Done");
 
         this.saveSettings();
     };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting, Modal, moment, debounce } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting, TFile, Modal, moment, debounce } from "obsidian";
 
 import { WebDb } from "./db/web_db";
 import { LocalDb } from "./db/local_db";
@@ -325,6 +325,26 @@ export class SettingTab extends PluginSettingTab {
                 .onClick(async () => {
                     await this.plugin.db.exportDB();
                     new Notice("Exported");
+                })
+            )
+            .addButton(button => button
+                .setButtonText(t("Backup"))
+                .onClick(async () => {
+                    let backupFile = this.app.vault.getAbstractFileByPath(
+                        // TODO: support for setting path
+                        "wordDB_backup.json"
+                    );
+
+                    if (!backupFile || "children" in backupFile) {
+                        new Notice("Invalid word database path");
+                        return;
+                    }
+                    const db_json = await this.plugin.db.readDB();
+                    let db = backupFile as TFile;
+                    await this.app.vault.modify(db, db_json)
+                    new Notice("Done");
+                    // }
+                    // fr.readAsText(file)
                 })
             );
         // 获取所有非无视单词


### PR DESCRIPTION
- Fix export indexDB on Android
- Add `Backup Local Database` command to export the whole indexDB
- [ ] Add support for setting backup file's directory. Now the path is hard-coded to be `wordDB_backup.json`
- [ ] Merge "Backup" and "Export" function

---

- 修复在安卓上导出indexDB的问题
- 添加“备份本地数据库”命令以导出整个indexDB
- [ ] 添加支持设置备份文件目录的功能。现在路径被硬编码为`wordDB_backup.json`
- [ ] 合并“备份”和“导出”功能